### PR TITLE
Erweiterung um API Version 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.linemetrics.monk</groupId>
     <artifactId>api</artifactId>
-    <version>1.2</version>
+    <version>1.3</version>
     <packaging>jar</packaging>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,12 @@
             <artifactId>json-simple</artifactId>
             <version>1.1.1</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.linemetrics.api</groupId>
+            <artifactId>sdk</artifactId>
+            <version>1.0.0.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/linemetrics/monk/api/ApiClient.java
+++ b/src/main/java/com/linemetrics/monk/api/ApiClient.java
@@ -34,7 +34,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.json.simple.JSONObject;
 
-public class ApiClient {
+public class ApiClient implements IApiClient {
 
     public static final String DEFAULT_API_REV = "v1";
     public static String apirev = DEFAULT_API_REV;

--- a/src/main/java/com/linemetrics/monk/api/ApiException.java
+++ b/src/main/java/com/linemetrics/monk/api/ApiException.java
@@ -18,8 +18,6 @@
 
 package com.linemetrics.monk.api;
 
-import java.lang.Throwable;
-
 /**
  * A generic LineMetrics API exception.
  */

--- a/src/main/java/com/linemetrics/monk/api/ApiManager.java
+++ b/src/main/java/com/linemetrics/monk/api/ApiManager.java
@@ -2,13 +2,13 @@ package com.linemetrics.monk.api;
 
 public class ApiManager {
 
-    static ApiClient apiClient;
+    static IApiClient apiClient;
 
-    public static void setClient(ApiClient api) {
+    public static void setClient(IApiClient api) {
         ApiManager.apiClient = api;
     }
 
-    public static ApiClient getClient() {
+    public static IApiClient getClient() {
         return ApiManager.apiClient;
     }
 

--- a/src/main/java/com/linemetrics/monk/api/IApiClient.java
+++ b/src/main/java/com/linemetrics/monk/api/IApiClient.java
@@ -1,0 +1,27 @@
+package com.linemetrics.monk.api;
+
+import com.linemetrics.monk.api.auth.HashBasedToken;
+import com.linemetrics.monk.dao.DataItem;
+import com.linemetrics.monk.dao.TDB;
+import org.json.simple.JSONObject;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.TimeZone;
+
+/**
+ * Created by Klemens on 13.03.2017.
+ */
+public interface IApiClient {
+
+    public List<DataItem> getRangeOptimized(
+            final Number dataStreamId,
+            long time_from,
+            long time_to,
+            TDB tdb,
+            TimeZone tz)
+            throws ApiException;
+
+    public HashBasedToken getToken(final String hash) throws ApiException;
+}

--- a/src/main/java/com/linemetrics/monk/api/IApiClient.java
+++ b/src/main/java/com/linemetrics/monk/api/IApiClient.java
@@ -3,10 +3,7 @@ package com.linemetrics.monk.api;
 import com.linemetrics.monk.api.auth.HashBasedToken;
 import com.linemetrics.monk.dao.DataItem;
 import com.linemetrics.monk.dao.TDB;
-import org.json.simple.JSONObject;
 
-import java.net.URI;
-import java.util.HashMap;
 import java.util.List;
 import java.util.TimeZone;
 
@@ -15,8 +12,10 @@ import java.util.TimeZone;
  */
 public interface IApiClient {
 
+    public void setJobProperties(String properties);
+
     public List<DataItem> getRangeOptimized(
-            final Number dataStreamId,
+            final String dataStreamProperties,
             long time_from,
             long time_to,
             TDB tdb,

--- a/src/main/java/com/linemetrics/monk/api/RestClient.java
+++ b/src/main/java/com/linemetrics/monk/api/RestClient.java
@@ -18,22 +18,21 @@
 
 package com.linemetrics.monk.api;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Map;
-
 import com.linemetrics.monk.api.auth.ICredentials;
 import org.apache.http.*;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.utils.URIBuilder;
-
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
 
 public class RestClient {
 

--- a/src/main/java/com/linemetrics/monk/api/auth/HashBasedCredential.java
+++ b/src/main/java/com/linemetrics/monk/api/auth/HashBasedCredential.java
@@ -26,7 +26,7 @@ public class HashBasedCredential
 
     private String hash;
 
-    private ApiClient client;
+    private IApiClient client;
 
     private HashBasedToken token;
 
@@ -34,7 +34,7 @@ public class HashBasedCredential
         this.hash = hash;
     }
 
-    public void initialize(ApiClient client) {
+    public void initialize(IApiClient client) {
         this.client = client;
     }
 

--- a/src/main/java/com/linemetrics/monk/api/auth/HashBasedCredential.java
+++ b/src/main/java/com/linemetrics/monk/api/auth/HashBasedCredential.java
@@ -18,7 +18,8 @@
 
 package com.linemetrics.monk.api.auth;
 
-import com.linemetrics.monk.api.*;
+import com.linemetrics.monk.api.ApiException;
+import com.linemetrics.monk.api.IApiClient;
 import org.apache.http.HttpRequest;
 
 public class HashBasedCredential

--- a/src/main/java/com/linemetrics/monk/api/auth/HashBasedToken.java
+++ b/src/main/java/com/linemetrics/monk/api/auth/HashBasedToken.java
@@ -18,8 +18,8 @@
 
 package com.linemetrics.monk.api.auth;
 
-import com.linemetrics.monk.api.Util;
 import com.linemetrics.monk.api.RestClient;
+import com.linemetrics.monk.api.Util;
 import org.json.simple.JSONObject;
 
 import java.util.Map;

--- a/src/main/java/com/linemetrics/monk/api/auth/ICredentials.java
+++ b/src/main/java/com/linemetrics/monk/api/auth/ICredentials.java
@@ -18,7 +18,6 @@
 
 package com.linemetrics.monk.api.auth;
 
-import com.linemetrics.monk.api.ApiClient;
 import com.linemetrics.monk.api.IApiClient;
 import com.linemetrics.monk.api.RestException;
 import org.apache.http.HttpRequest;

--- a/src/main/java/com/linemetrics/monk/api/auth/ICredentials.java
+++ b/src/main/java/com/linemetrics/monk/api/auth/ICredentials.java
@@ -19,12 +19,13 @@
 package com.linemetrics.monk.api.auth;
 
 import com.linemetrics.monk.api.ApiClient;
+import com.linemetrics.monk.api.IApiClient;
 import com.linemetrics.monk.api.RestException;
 import org.apache.http.HttpRequest;
 
 public interface ICredentials {
 
-    void initialize(ApiClient client) throws RestException;
+    void initialize(IApiClient client) throws RestException;
 
     /**
      * Sets the Authorization header for the given request.

--- a/src/main/java/com/linemetrics/monk/api/auth/SecretBasedCredential.java
+++ b/src/main/java/com/linemetrics/monk/api/auth/SecretBasedCredential.java
@@ -1,0 +1,40 @@
+package com.linemetrics.monk.api.auth;
+
+import com.linemetrics.monk.api.ApiClient;
+import com.linemetrics.monk.api.IApiClient;
+import com.linemetrics.monk.api.RestException;
+import org.apache.http.HttpRequest;
+
+/**
+ * Created by Klemens on 14.03.2017.
+ */
+public class SecretBasedCredential implements ICredentials {
+
+    private IApiClient client;
+
+    private String clientId;
+    private String clientSecret;
+
+    public SecretBasedCredential(String clientId, String clientSecret){
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+    }
+
+    @Override
+    public void initialize(IApiClient client) throws RestException {
+        this.client = client;
+    }
+
+    @Override
+    public void authenticate(HttpRequest req) {
+
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+}

--- a/src/main/java/com/linemetrics/monk/api/auth/SecretBasedCredential.java
+++ b/src/main/java/com/linemetrics/monk/api/auth/SecretBasedCredential.java
@@ -1,6 +1,5 @@
 package com.linemetrics.monk.api.auth;
 
-import com.linemetrics.monk.api.ApiClient;
 import com.linemetrics.monk.api.IApiClient;
 import com.linemetrics.monk.api.RestException;
 import org.apache.http.HttpRequest;

--- a/src/main/java/com/linemetrics/monk/apiv2/ApiClient.java
+++ b/src/main/java/com/linemetrics/monk/apiv2/ApiClient.java
@@ -3,6 +3,7 @@ package com.linemetrics.monk.apiv2;
 import com.linemetrics.api.ILMService;
 import com.linemetrics.api.LineMetricsService;
 import com.linemetrics.api.datatypes.Base;
+import com.linemetrics.api.datatypes.Double;
 import com.linemetrics.api.datatypes.DoubleAverage;
 import com.linemetrics.api.exceptions.AuthorizationException;
 import com.linemetrics.api.exceptions.ServiceException;
@@ -12,18 +13,16 @@ import com.linemetrics.api.returntypes.RawDataReadResponse;
 import com.linemetrics.api.types.FunctionType;
 import com.linemetrics.monk.api.ApiException;
 import com.linemetrics.monk.api.IApiClient;
-import com.linemetrics.monk.api.RestClient;
 import com.linemetrics.monk.api.RestException;
 import com.linemetrics.monk.api.auth.HashBasedToken;
 import com.linemetrics.monk.api.auth.ICredentials;
 import com.linemetrics.monk.api.auth.SecretBasedCredential;
 import com.linemetrics.monk.dao.DataItem;
 import com.linemetrics.monk.dao.TDB;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.commons.lang3.StringUtils;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -36,10 +35,17 @@ public class ApiClient implements IApiClient {
 
     private ICredentials credentials;
     private ILMService api;
+    private JSONObject jobProperties;
+
+    public static int MAX_RETRIES = 5;
+    public static int WAIT_MILLIS_AFTER_ERROR = 10 * 1000;
 
     public ApiClient(String uri, ICredentials creds) throws RestException {
         this.credentials = creds;
         try {
+            if(credentials == null || !(credentials instanceof  SecretBasedCredential)){
+                throw new RestException("Invalid credential settings", 500);
+            }
             api = new LineMetricsService(((SecretBasedCredential)credentials).getClientId(), ((SecretBasedCredential)credentials).getClientSecret());
         } catch(ServiceException e){
             throw new RestException(e.getMessage(), 500);
@@ -47,23 +53,52 @@ public class ApiClient implements IApiClient {
     }
 
     @Override
-    public List<DataItem> getRangeOptimized(Number dataStreamId, long time_from, long time_to, TDB tdb, TimeZone tz) throws ApiException {
+    public void setJobProperties(String properties) {
+        this.jobProperties = (JSONObject) JSONValue.parse(properties);
+    }
+
+    private String extractFieldFromJson(JSONObject object, String key){
+        return object!=null&&object.containsKey(key)?(String)object.get(key):null;
+    }
+
+    @Override
+    public List<DataItem> getRangeOptimized(final String dataStreamProperties, long time_from, long time_to, TDB tdb, TimeZone tz) throws ApiException {
         final List<DataItem> result = new ArrayList<>();
+        JSONObject datastream = (JSONObject)JSONValue.parse(dataStreamProperties);
+
+        String object_id = extractFieldFromJson(datastream, "id");
+        String customKey = extractFieldFromJson(datastream, "customkey");
+        String alias = extractFieldFromJson(datastream, "alias");
+        String granularity = extractFieldFromJson(this.jobProperties, "batch_size");
+
         if(api != null) {
-            int authErrorCounter = 0;
-            boolean run = true;
+            int retries = MAX_RETRIES;
+            boolean isError = false;
 
-            while(run){
-                run = false;
+            while(retries-- >= 0){
+
+                if(isError) {
+                    System.out.println("WAIT CAUSE OF ERROR AND RETRY (" + (MAX_RETRIES - retries) + ")...");
+                    try {
+                        Thread.sleep(WAIT_MILLIS_AFTER_ERROR);
+                    } catch(InterruptedException iexp) { }
+                }
+                isError = false;
+
                 try {
-                    DataStream ds = (DataStream) api.loadObject("2c7c94eb76df497d90e33cdf9f97c5f4"); //TODO replace with dataStreamId
+                    DataStream ds = null;
+                    if(StringUtils.isNotEmpty(customKey) && StringUtils.isNotEmpty(alias)){
+                        ds = (DataStream) api.loadObject(customKey, alias);
+                    } else if(StringUtils.isNotEmpty(object_id)){
+                        ds = (DataStream) api.loadObject(object_id);
+                    } else {
+                        System.err.println(String.format("Invalid properties for datastream"));
+                        return result;
+                    }
 
-                    System.out.println(String.format("Call API with params time_from: %s, " +
-                                    "time_to: %s, timezone: %s, granularity: %s, type: %s"
-                        , new Date(time_from), new Date(time_to), tz.getID(), "PT1M", "raw"));
+                    List<DataReadResponse> list = ds.loadData(new Date(time_from), new Date(time_to), tz.getID(), StringUtils.isNotEmpty(granularity)?
+                        granularity.toUpperCase():"PT1M", FunctionType.RAW);
 
-                    List<DataReadResponse> list = ds.loadData(new Date(time_from), new Date(time_to), tz.getID(), "PT1M", FunctionType.RAW);
-                    System.out.println("Resultlist size: "+list.size());
                     if (list != null) {
                         for (DataReadResponse entry : list) {
                             if (entry instanceof RawDataReadResponse) {
@@ -74,23 +109,28 @@ public class ApiClient implements IApiClient {
                             }
                         }
                     }
+
+                    //succesfully loaded data
+                    break;
+
                 } catch(AuthorizationException e){
-                    e.printStackTrace(); //TODO remove
-                    //if token is expired run again
-                    if(e.getMessage() != null && "Access denied. Auth Token expired?".equalsIgnoreCase(e.getMessage())){
-                        authErrorCounter++;
-                        if(authErrorCounter <= 1){
-                            run = true;
-                            try {
-                                api.refreshToken();
-                            } catch(ServiceException se){
-                                throw new ApiException(se.getMessage(), se);
-                            }
-                        }
+                    //check if token is expired - if yes -> refresh
+                    try {
+                        api.refreshToken();
+                    } catch(ServiceException se){
+                        throw new ApiException(se.getMessage(), se);
                     }
                 } catch(ServiceException e){
+                    e.printStackTrace();
+                    isError = true;
+                } catch(Exception e){
+                    e.printStackTrace();
                     throw new ApiException(e.getMessage(), e);
                 }
+            }
+
+            if(isError){
+                throw new ApiException("Unable to grab data");
             }
         }
         return result;
@@ -99,7 +139,12 @@ public class ApiClient implements IApiClient {
     private DataItem mapItem(final RawDataReadResponse entry, Base type){
         if(entry != null && entry.getData() instanceof DoubleAverage){
             DoubleAverage da = ((DoubleAverage)entry.getData());
-            return new DataItem(da.getMinimum(), da.getMaximum(), da.getValue(), da.getTimestamp().getTime());
+            return new DataItem(da.getMinimum(), da.getMaximum(), da.getValue(), da.getTimestamp().getTime(), da.getTimestamp().getTime());
+        } else if(entry != null && entry.getData() instanceof Double){
+            Double d = ((Double)entry.getData());
+            return new DataItem(d.getValue(), d.getValue(), d.getValue(), d.getTimestamp().getTime(), d.getTimestamp().getTime());
+        } else {
+            System.err.println(String.format("Unknown Datatype: %", type.toString()));
         }
         return null;
     }

--- a/src/main/java/com/linemetrics/monk/apiv2/ApiClient.java
+++ b/src/main/java/com/linemetrics/monk/apiv2/ApiClient.java
@@ -1,0 +1,111 @@
+package com.linemetrics.monk.apiv2;
+
+import com.linemetrics.api.ILMService;
+import com.linemetrics.api.LineMetricsService;
+import com.linemetrics.api.datatypes.Base;
+import com.linemetrics.api.datatypes.DoubleAverage;
+import com.linemetrics.api.exceptions.AuthorizationException;
+import com.linemetrics.api.exceptions.ServiceException;
+import com.linemetrics.api.returntypes.DataReadResponse;
+import com.linemetrics.api.returntypes.DataStream;
+import com.linemetrics.api.returntypes.RawDataReadResponse;
+import com.linemetrics.api.types.FunctionType;
+import com.linemetrics.monk.api.ApiException;
+import com.linemetrics.monk.api.IApiClient;
+import com.linemetrics.monk.api.RestClient;
+import com.linemetrics.monk.api.RestException;
+import com.linemetrics.monk.api.auth.HashBasedToken;
+import com.linemetrics.monk.api.auth.ICredentials;
+import com.linemetrics.monk.api.auth.SecretBasedCredential;
+import com.linemetrics.monk.dao.DataItem;
+import com.linemetrics.monk.dao.TDB;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+
+/**
+ * Created by Klemens on 13.03.2017.
+ */
+public class ApiClient implements IApiClient {
+
+    private ICredentials credentials;
+    private ILMService api;
+
+    public ApiClient(String uri, ICredentials creds) throws RestException {
+        this.credentials = creds;
+        try {
+            api = new LineMetricsService(((SecretBasedCredential)credentials).getClientId(), ((SecretBasedCredential)credentials).getClientSecret());
+        } catch(ServiceException e){
+            throw new RestException(e.getMessage(), 500);
+        }
+    }
+
+    @Override
+    public List<DataItem> getRangeOptimized(Number dataStreamId, long time_from, long time_to, TDB tdb, TimeZone tz) throws ApiException {
+        final List<DataItem> result = new ArrayList<>();
+        if(api != null) {
+            int authErrorCounter = 0;
+            boolean run = true;
+
+            while(run){
+                run = false;
+                try {
+                    DataStream ds = (DataStream) api.loadObject("2c7c94eb76df497d90e33cdf9f97c5f4"); //TODO replace with dataStreamId
+
+                    System.out.println(String.format("Call API with params time_from: %s, " +
+                                    "time_to: %s, timezone: %s, granularity: %s, type: %s"
+                        , new Date(time_from), new Date(time_to), tz.getID(), "PT1M", "raw"));
+
+                    List<DataReadResponse> list = ds.loadData(new Date(time_from), new Date(time_to), tz.getID(), "PT1M", FunctionType.RAW);
+                    System.out.println("Resultlist size: "+list.size());
+                    if (list != null) {
+                        for (DataReadResponse entry : list) {
+                            if (entry instanceof RawDataReadResponse) {
+                                DataItem item = mapItem((RawDataReadResponse) entry, null);
+                                if (item != null) {
+                                    result.add(item);
+                                }
+                            }
+                        }
+                    }
+                } catch(AuthorizationException e){
+                    e.printStackTrace(); //TODO remove
+                    //if token is expired run again
+                    if(e.getMessage() != null && "Access denied. Auth Token expired?".equalsIgnoreCase(e.getMessage())){
+                        authErrorCounter++;
+                        if(authErrorCounter <= 1){
+                            run = true;
+                            try {
+                                api.refreshToken();
+                            } catch(ServiceException se){
+                                throw new ApiException(se.getMessage(), se);
+                            }
+                        }
+                    }
+                } catch(ServiceException e){
+                    throw new ApiException(e.getMessage(), e);
+                }
+            }
+        }
+        return result;
+    }
+
+    private DataItem mapItem(final RawDataReadResponse entry, Base type){
+        if(entry != null && entry.getData() instanceof DoubleAverage){
+            DoubleAverage da = ((DoubleAverage)entry.getData());
+            return new DataItem(da.getMinimum(), da.getMaximum(), da.getValue(), da.getTimestamp().getTime());
+        }
+        return null;
+    }
+
+    @Override
+    public HashBasedToken getToken(final String hash) throws ApiException {
+        return null;
+    }
+}

--- a/src/main/java/com/linemetrics/monk/dao/DataItem.java
+++ b/src/main/java/com/linemetrics/monk/dao/DataItem.java
@@ -47,6 +47,14 @@ public class DataItem {
         this.timestampStart = timestampStart;
     }
 
+    public DataItem(Double min, Double max, Double value, Long timestampStart, Long timestampEnd){
+        this.min = min;
+        this.max = max;
+        this.value = value;
+        this.timestampStart = timestampStart;
+        this.timestampEnd = timestampEnd;
+    }
+
     private DataItem() {}
 
     public static DataItem empty() {

--- a/src/main/java/com/linemetrics/monk/dao/DataItem.java
+++ b/src/main/java/com/linemetrics/monk/dao/DataItem.java
@@ -40,6 +40,13 @@ public class DataItem {
         }
     }
 
+    public DataItem(Double min, Double max, Double value, Long timestampStart){
+        this.min = min;
+        this.max = max;
+        this.value = value;
+        this.timestampStart = timestampStart;
+    }
+
     private DataItem() {}
 
     public static DataItem empty() {


### PR DESCRIPTION
- Erhöhung der Versionsnummer auf 1.3
- Das Interface IApiClient wurde hinzugefügt
- ApiClient für ApiV2 wurde hinzugefügt und implementiert das Interface IApiClient (inklusive Methode getRangeOptimized)
- ApiClient für AviV1 implementiert nun IApiClient
- Die Methode getRangeOptimized bekommt anstatt der DataStreamId nun einen (JSON)String der Properties beinhaltet übergeben
- ApiManager hält nun das Interface IApiClient anstatt von ApiClient Implementierung
- SecretBasedCredential wurde hinzugefügt, für Authentifizierung gegen ApiV2
- Unnötige Importstatements wurden entfernt

Offene Fragen:
- Soll die APIv2 immer mittels Function "raw" abgefragt werden und die Verarbeitung wird dem Compressor Plugin überlassen oder soll es ein neues Property geben das direkt die Function (raw,sum,average) für den Aufruf an die API definiert (bzw. würde das funktionieren?)
